### PR TITLE
Add README example for grouping package.json updates with deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ dependencies:
 
 ![yarn.lock deps pull request example](https://user-images.githubusercontent.com/649496/136111016-480de2d8-5ede-4dc0-90a4-201df83249da.png)
 
+Most of the time, the lockfile updates will account for your "grouped" dependencies that need to be updated together (since those updates are usually all within your package.json ranges). But you can also group out-of-range package.json updates by using [filters](https://deps.app/config/#grouping-related-updates).
+
+```yaml
+version: 3
+dependencies:
+- type: js
+  path: app
+  manifest_updates:
+    filters:
+    - name: remark-lint-.*
+      group: true
+    - name: .*
+      group: false
+```
+
 ## Support
 
 Any questions or issues with this specific component should be discussed in [GitHub issues](https://github.com/dropseed/deps-js/issues).


### PR DESCRIPTION
Probably helpful to show more concrete examples of how grouping can work in [deps](https://www.dependencies.io/). But separating lockfile and manifest updates out of the box really does what you need 90% of the time.

Related: https://github.com/dependabot/dependabot-core/issues/1190